### PR TITLE
fix(docker-entrypoint): ensure DATABASE_URL is set only if not alread…

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # Script de inicialização que constrói DATABASE_URL a partir de variáveis individuais
 # Se DB_HOST, DB_USER, DB_PASS, DB_NAME estiverem definidas, constrói DATABASE_URL
 
-if [ -n "$DB_HOST" ] && [ -n "$DB_USER" ] && [ -n "$DB_PASS" ] && [ -n "$DB_NAME" ]; then
+if [ -z "$DATABASE_URL" ] && [ -n "$DB_HOST" ] && [ -n "$DB_USER" ] && [ -n "$DB_PASS" ] && [ -n "$DB_NAME" ]; then
     DB_PORT="${DB_PORT:-5432}"
     DB_SCHEMA="${DB_SCHEMA:-public}"
     export DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}?schema=${DB_SCHEMA}"


### PR DESCRIPTION
…y defined

- Updated the condition in the docker-entrypoint.sh script to check if DATABASE_URL is unset before constructing it from individual database variables (DB_HOST, DB_USER, DB_PASS, DB_NAME).
- This change prevents overwriting an existing DATABASE_URL, ensuring the script behaves correctly in various deployment scenarios.

## Descrição

<!-- Descreva as mudanças feitas nesta PR -->

## Tipo de Mudança

- [ ] 🐛 Bug fix
- [ ] ✨ Nova funcionalidade
- [ ] 🔧 Refatoração
- [ ] 📝 Documentação
- [ ] 🧪 Testes
- [ ] ⚙️ Configuração/Deploy

## Checklist

- [ ] Código segue os padrões do projeto
- [ ] Testes foram adicionados/atualizados
- [ ] Documentação foi atualizada (se necessário)
- [ ] `npm run validate` passa sem erros
- [ ] Não há warnings do linter

## Testes

<!-- Descreva como testar as mudanças -->

## Screenshots (se aplicável)

<!-- Adicione screenshots se a mudança afetar a UI -->
