### PR TITLE
feat(auth): implement user suspension check during authentication

### DIFF
--- a/src/application/services/auth/auth.service.spec.ts
+++ b/src/application/services/auth/auth.service.spec.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { CompanyUser } from '@/core/domain/company-user/company-user.entity';
-import { CompanyUserStatus, DocumentType, UserRole, UserStatus } from '@/core/domain/shared/enums';
+import {
+  CompanyUserStatus,
+  DocumentType,
+  UserRole,
+  UserStatus,
+} from '@/core/domain/shared/enums';
 import { AuthenticationException } from '@/core/domain/shared/exceptions/domain.exception';
 import { User } from '@/core/domain/user/user.entity';
 import type { CompanyUserRepository } from '@/core/ports/repositories/company-user.repository';
@@ -218,7 +223,9 @@ describe('AuthService', () => {
       const result = await service.login(loginInput);
 
       expect(result.access_token).toBe(expectedToken);
-      expect(companyUserRepository.findByUserId).toHaveBeenCalledWith('executor-id');
+      expect(companyUserRepository.findByUserId).toHaveBeenCalledWith(
+        'executor-id',
+      );
     });
 
     it('should throw AuthenticationException for non-admin user suspended in all companies', async () => {
@@ -246,7 +253,9 @@ describe('AuthService', () => {
 
       userRepository.findByEmail.mockResolvedValue(executorUser);
       passwordHasher.compare.mockResolvedValue(true);
-      companyUserRepository.findByUserId.mockResolvedValue([suspendedCompanyUser]);
+      companyUserRepository.findByUserId.mockResolvedValue([
+        suspendedCompanyUser,
+      ]);
 
       await expect(service.login(loginInput)).rejects.toThrow(
         AuthenticationException,
@@ -254,7 +263,9 @@ describe('AuthService', () => {
       await expect(service.login(loginInput)).rejects.toThrow(
         'Sua conta está suspensa. Entre em contato com o administrador.',
       );
-      expect(companyUserRepository.findByUserId).toHaveBeenCalledWith('executor-id');
+      expect(companyUserRepository.findByUserId).toHaveBeenCalledWith(
+        'executor-id',
+      );
       expect(jwtService.signAsync).not.toHaveBeenCalled();
     });
 
@@ -282,7 +293,9 @@ describe('AuthService', () => {
       const result = await service.login(loginInput);
 
       expect(result.access_token).toBe(expectedToken);
-      expect(companyUserRepository.findByUserId).toHaveBeenCalledWith('executor-id');
+      expect(companyUserRepository.findByUserId).toHaveBeenCalledWith(
+        'executor-id',
+      );
     });
   });
 });

--- a/src/application/services/auth/auth.service.spec.ts
+++ b/src/application/services/auth/auth.service.spec.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { DocumentType, UserRole, UserStatus } from '@/core/domain/shared/enums';
+import { CompanyUser } from '@/core/domain/company-user/company-user.entity';
+import { CompanyUserStatus, DocumentType, UserRole, UserStatus } from '@/core/domain/shared/enums';
 import { AuthenticationException } from '@/core/domain/shared/exceptions/domain.exception';
 import { User } from '@/core/domain/user/user.entity';
+import type { CompanyUserRepository } from '@/core/ports/repositories/company-user.repository';
 import type { UserRepository } from '@/core/ports/repositories/user.repository';
 import type { PasswordHasher } from '@/core/ports/services/password-hasher.port';
 import { JwtService } from '@nestjs/jwt';
@@ -11,6 +13,7 @@ import { AuthService, type LoginInput } from './auth.service';
 describe('AuthService', () => {
   let service: AuthService;
   let userRepository: jest.Mocked<UserRepository>;
+  let companyUserRepository: jest.Mocked<CompanyUserRepository>;
   let passwordHasher: jest.Mocked<PasswordHasher>;
   let jwtService: jest.Mocked<JwtService>;
 
@@ -38,6 +41,20 @@ describe('AuthService', () => {
       findAll: jest.fn(),
     };
 
+    const mockCompanyUserRepository = {
+      findByUserId: jest.fn(),
+      findById: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findByCompanyId: jest.fn(),
+      findByCompanyAndUser: jest.fn(),
+      findByCompanyIdAndStatus: jest.fn(),
+      findByCompanyIdPaginated: jest.fn(),
+      countByAdminIdAndRole: jest.fn(),
+      countByAdminIdRoleAndStatus: jest.fn(),
+    };
+
     const mockPasswordHasher = {
       hash: jest.fn(),
       compare: jest.fn(),
@@ -56,6 +73,10 @@ describe('AuthService', () => {
           useValue: mockUserRepository,
         },
         {
+          provide: 'CompanyUserRepository',
+          useValue: mockCompanyUserRepository,
+        },
+        {
           provide: 'PasswordHasher',
           useValue: mockPasswordHasher,
         },
@@ -68,6 +89,7 @@ describe('AuthService', () => {
 
     service = module.get<AuthService>(AuthService);
     userRepository = module.get('UserRepository');
+    companyUserRepository = module.get('CompanyUserRepository');
     passwordHasher = module.get('PasswordHasher');
     jwtService = module.get(JwtService);
   });
@@ -86,6 +108,7 @@ describe('AuthService', () => {
       const expectedToken = 'jwt_token_123';
       userRepository.findByEmail.mockResolvedValue(mockUser);
       passwordHasher.compare.mockResolvedValue(true);
+      // Admin não precisa verificar CompanyUser
       jwtService.signAsync.mockResolvedValue(expectedToken);
 
       const result = await service.login(loginInput);
@@ -110,6 +133,8 @@ describe('AuthService', () => {
         email: mockUser.email,
         role: mockUser.role,
       });
+      // Admin não verifica CompanyUser
+      expect(companyUserRepository.findByUserId).not.toHaveBeenCalled();
     });
 
     it('should throw AuthenticationException when user does not exist', async () => {
@@ -159,6 +184,105 @@ describe('AuthService', () => {
           role: expect.any(String),
         }),
       );
+    });
+
+    it('should allow login for non-admin user with active company', async () => {
+      const executorUser = new User(
+        'executor-id',
+        'Executor',
+        'User',
+        'executor@example.com',
+        '11987654321',
+        '12345678900',
+        DocumentType.CPF,
+        'hashed_password_123',
+        UserRole.EXECUTOR,
+        UserStatus.ACTIVE,
+        null,
+      );
+
+      const activeCompanyUser = new CompanyUser(
+        'cu-1',
+        'company-1',
+        'executor-id',
+        UserRole.EXECUTOR,
+        CompanyUserStatus.ACTIVE,
+      );
+
+      const expectedToken = 'jwt_token_executor';
+      userRepository.findByEmail.mockResolvedValue(executorUser);
+      passwordHasher.compare.mockResolvedValue(true);
+      companyUserRepository.findByUserId.mockResolvedValue([activeCompanyUser]);
+      jwtService.signAsync.mockResolvedValue(expectedToken);
+
+      const result = await service.login(loginInput);
+
+      expect(result.access_token).toBe(expectedToken);
+      expect(companyUserRepository.findByUserId).toHaveBeenCalledWith('executor-id');
+    });
+
+    it('should throw AuthenticationException for non-admin user suspended in all companies', async () => {
+      const executorUser = new User(
+        'executor-id',
+        'Executor',
+        'User',
+        'executor@example.com',
+        '11987654321',
+        '12345678900',
+        DocumentType.CPF,
+        'hashed_password_123',
+        UserRole.EXECUTOR,
+        UserStatus.ACTIVE,
+        null,
+      );
+
+      const suspendedCompanyUser = new CompanyUser(
+        'cu-1',
+        'company-1',
+        'executor-id',
+        UserRole.EXECUTOR,
+        CompanyUserStatus.SUSPENDED,
+      );
+
+      userRepository.findByEmail.mockResolvedValue(executorUser);
+      passwordHasher.compare.mockResolvedValue(true);
+      companyUserRepository.findByUserId.mockResolvedValue([suspendedCompanyUser]);
+
+      await expect(service.login(loginInput)).rejects.toThrow(
+        AuthenticationException,
+      );
+      await expect(service.login(loginInput)).rejects.toThrow(
+        'Sua conta está suspensa. Entre em contato com o administrador.',
+      );
+      expect(companyUserRepository.findByUserId).toHaveBeenCalledWith('executor-id');
+      expect(jwtService.signAsync).not.toHaveBeenCalled();
+    });
+
+    it('should allow login for non-admin user without companies', async () => {
+      const executorUser = new User(
+        'executor-id',
+        'Executor',
+        'User',
+        'executor@example.com',
+        '11987654321',
+        '12345678900',
+        DocumentType.CPF,
+        'hashed_password_123',
+        UserRole.EXECUTOR,
+        UserStatus.ACTIVE,
+        null,
+      );
+
+      const expectedToken = 'jwt_token_executor';
+      userRepository.findByEmail.mockResolvedValue(executorUser);
+      passwordHasher.compare.mockResolvedValue(true);
+      companyUserRepository.findByUserId.mockResolvedValue([]);
+      jwtService.signAsync.mockResolvedValue(expectedToken);
+
+      const result = await service.login(loginInput);
+
+      expect(result.access_token).toBe(expectedToken);
+      expect(companyUserRepository.findByUserId).toHaveBeenCalledWith('executor-id');
     });
   });
 });

--- a/src/shared/constants/error-messages.ts
+++ b/src/shared/constants/error-messages.ts
@@ -100,6 +100,8 @@ export const ErrorMessages = {
     INVALID_OR_EXPIRED_RESET_TOKEN: 'Token de recuperação inválido ou expirado',
     LEGACY_INVITE_TOKEN:
       'Token de convite inválido. Este token foi gerado antes da atualização do sistema. Por favor, solicite um novo convite.',
+    USER_SUSPENDED:
+      'Sua conta está suspensa. Entre em contato com o administrador.',
   },
 
   ACTION: {


### PR DESCRIPTION
- Added logic to verify if a non-admin user is suspended based on their associated companies' statuses.
- Introduced a new error message for suspended accounts to enhance user feedback during login attempts.
- Updated the error messages constant to include a USER_SUSPENDED message for clarity.

## Descrição

<!-- Descreva as mudanças feitas nesta PR -->

## Tipo de Mudança

- [ ] 🐛 Bug fix
- [ ] ✨ Nova funcionalidade
- [ ] 🔧 Refatoração
- [ ] 📝 Documentação
- [ ] 🧪 Testes
- [ ] ⚙️ Configuração/Deploy

## Checklist

- [ ] Código segue os padrões do projeto
- [ ] Testes foram adicionados/atualizados
- [ ] Documentação foi atualizada (se necessário)
- [ ] `npm run validate` passa sem erros
- [ ] Não há warnings do linter

## Testes

<!-- Descreva como testar as mudanças -->

## Screenshots (se aplicável)

<!-- Adicione screenshots se a mudança afetar a UI -->
