### PR TITLE
feat(auth): update RegisterAdminDto and service to handle optional do…

### DIFF
--- a/src/api/auth/dto/register-admin.dto.ts
+++ b/src/api/auth/dto/register-admin.dto.ts
@@ -8,6 +8,7 @@ import {
   IsOptional,
   IsString,
   MinLength,
+  ValidateIf,
   ValidateNested,
 } from 'class-validator';
 
@@ -73,17 +74,21 @@ export class RegisterAdminDto {
   @ApiProperty({
     description: 'Documento do administrador (CPF ou CNPJ)',
     example: '12345678900',
+    required: false,
   })
+  @IsOptional()
   @IsString({ message: 'O documento deve ser uma string' })
-  document!: string;
+  document?: string;
 
   @ApiProperty({
     description: 'Tipo de documento',
     enum: DocumentType,
     example: DocumentType.CPF,
+    required: false,
   })
+  @ValidateIf((o) => o.document !== undefined && o.document !== null)
   @IsEnum(DocumentType, { message: 'O tipo de documento deve ser CPF ou CNPJ' })
-  documentType!: DocumentType;
+  documentType?: DocumentType;
 
   @ApiProperty({
     description: 'Dados da empresa',

--- a/src/core/domain/user/user.entity.ts
+++ b/src/core/domain/user/user.entity.ts
@@ -44,6 +44,7 @@ export class User extends Entity {
       this.phone,
       ErrorMessages.USER.PHONE_REQUIRED,
     );
+    // Documento é obrigatório, mas pode ser temporário (temp_*) quando não fornecido
     DomainValidator.validateRequiredString(
       this.document,
       ErrorMessages.USER.DOCUMENT_REQUIRED,


### PR DESCRIPTION
…cument fields

- Made 'document' and 'documentType' optional in RegisterAdminDto and RegisterAdminInput.
- Updated RegisterAdminService to generate a temporary document if not provided and validate uniqueness only when a document is supplied.
- Enhanced user entity validation to allow temporary documents while ensuring required fields are checked.

## Descrição

<!-- Descreva as mudanças feitas nesta PR -->

## Tipo de Mudança

- [ ] 🐛 Bug fix
- [ ] ✨ Nova funcionalidade
- [ ] 🔧 Refatoração
- [ ] 📝 Documentação
- [ ] 🧪 Testes
- [ ] ⚙️ Configuração/Deploy

## Checklist

- [ ] Código segue os padrões do projeto
- [ ] Testes foram adicionados/atualizados
- [ ] Documentação foi atualizada (se necessário)
- [ ] `npm run validate` passa sem erros
- [ ] Não há warnings do linter

## Testes

<!-- Descreva como testar as mudanças -->

## Screenshots (se aplicável)

<!-- Adicione screenshots se a mudança afetar a UI -->
